### PR TITLE
support remove wildcard argument

### DIFF
--- a/aztfq/aztfq.go
+++ b/aztfq/aztfq.go
@@ -11,15 +11,20 @@ import (
 	"github.com/magodo/azure-rest-api-bridge/mockserver/swagger"
 )
 
-func BuildLookupTable(input []byte, removeArraySymbol bool) (LookupTable, error) {
+type Option struct {
+	// ImplicitArrayIndex makes the array index to be implicit, e.g. "foos.*.id" -> "foos.id".
+	ImplicitArrayIndex bool
+}
+
+func BuildLookupTable(input []byte, opt Option) (LookupTable, error) {
 	var output map[string]ctrl.ModelMap
 	if err := json.Unmarshal(input, &output); err != nil {
 		return LookupTable{}, err
 	}
-	return buildLookupTable(output, removeArraySymbol)
+	return buildLookupTable(output, opt)
 }
 
-func buildLookupTable(output map[string]ctrl.ModelMap, removeArraySymbol bool) (LookupTable, error) {
+func buildLookupTable(output map[string]ctrl.ModelMap, opt Option) (LookupTable, error) {
 	t := LookupTable{}
 	for tfRT, mm := range output {
 		for tfPropAddr, apiPoses := range mm {
@@ -55,7 +60,7 @@ func buildLookupTable(output map[string]ctrl.ModelMap, removeArraySymbol bool) (
 				}
 
 				apiAddr := apiPos.Addr
-				if removeArraySymbol {
+				if opt.ImplicitArrayIndex {
 					apiAddr = removeArrayWildcard(apiAddr)
 				}
 				apiPropAddr := apiAddr.String()

--- a/aztfq/aztfq.go
+++ b/aztfq/aztfq.go
@@ -8,17 +8,18 @@ import (
 	"strings"
 
 	"github.com/magodo/azure-rest-api-bridge/ctrl"
+	"github.com/magodo/azure-rest-api-bridge/mockserver/swagger"
 )
 
-func BuildLookupTable(input []byte) (LookupTable, error) {
+func BuildLookupTable(input []byte, removeArraySymbol bool) (LookupTable, error) {
 	var output map[string]ctrl.ModelMap
 	if err := json.Unmarshal(input, &output); err != nil {
 		return LookupTable{}, err
 	}
-	return buildLookupTable(output)
+	return buildLookupTable(output, removeArraySymbol)
 }
 
-func buildLookupTable(output map[string]ctrl.ModelMap) (LookupTable, error) {
+func buildLookupTable(output map[string]ctrl.ModelMap, removeArraySymbol bool) (LookupTable, error) {
 	t := LookupTable{}
 	for tfRT, mm := range output {
 		for tfPropAddr, apiPoses := range mm {
@@ -53,7 +54,19 @@ func buildLookupTable(output map[string]ctrl.ModelMap) (LookupTable, error) {
 					tt[""] = tttAny
 				}
 
-				apiPropAddr := apiPos.Addr.String()
+				apiAddr := apiPos.Addr
+				if removeArraySymbol {
+					newApiAddr := make(swagger.PropertyAddr, 0)
+					for _, step := range apiAddr {
+						if step.Type != swagger.PropertyAddrStepTypeIndex {
+							newApiAddr = append(newApiAddr, step)
+						}
+					}
+					apiAddr = newApiAddr
+
+				}
+				apiPropAddr := apiAddr.String()
+
 				ttt[apiPropAddr] = append(ttt[apiPropAddr], TFResult{
 					ResourceType: tfRT,
 					PropertyAddr: tfPropAddr,
@@ -122,5 +135,5 @@ type TFResult struct {
 // LookupTable is the main lookup table used for querying.
 // key1: Azure resource type in upper case (e.g. MICROSOFT.COMPUTE/VIRTUALMACHINES)
 // key2: API version. Especially, there is always an empty string ("") key represents any api version.
-// key2: Azure resource property address (e.g. properties.object.key, values.*.id)
+// key3: Azure resource property address (e.g. properties.object.key, values.*.id)
 type LookupTable map[string]map[string]map[string][]TFResult

--- a/aztfq/aztfq.go
+++ b/aztfq/aztfq.go
@@ -16,7 +16,13 @@ type Option struct {
 	ImplicitArrayIndex bool
 }
 
-func BuildLookupTable(input []byte, opt Option) (LookupTable, error) {
+func BuildLookupTable(input []byte, opt *Option) (LookupTable, error) {
+	if opt == nil {
+		opt = &Option{
+			ImplicitArrayIndex: false,
+		}
+	}
+
 	var output map[string]ctrl.ModelMap
 	if err := json.Unmarshal(input, &output); err != nil {
 		return LookupTable{}, err
@@ -24,7 +30,7 @@ func BuildLookupTable(input []byte, opt Option) (LookupTable, error) {
 	return buildLookupTable(output, opt)
 }
 
-func buildLookupTable(output map[string]ctrl.ModelMap, opt Option) (LookupTable, error) {
+func buildLookupTable(output map[string]ctrl.ModelMap, opt *Option) (LookupTable, error) {
 	t := LookupTable{}
 	for tfRT, mm := range output {
 		for tfPropAddr, apiPoses := range mm {

--- a/aztfq/aztfq.go
+++ b/aztfq/aztfq.go
@@ -56,14 +56,7 @@ func buildLookupTable(output map[string]ctrl.ModelMap, removeArraySymbol bool) (
 
 				apiAddr := apiPos.Addr
 				if removeArraySymbol {
-					newApiAddr := make(swagger.PropertyAddr, 0)
-					for _, step := range apiAddr {
-						if step.Type != swagger.PropertyAddrStepTypeIndex {
-							newApiAddr = append(newApiAddr, step)
-						}
-					}
-					apiAddr = newApiAddr
-
+					apiAddr = removeArrayWildcard(apiAddr)
 				}
 				apiPropAddr := apiAddr.String()
 
@@ -102,6 +95,17 @@ func buildLookupTable(output map[string]ctrl.ModelMap, removeArraySymbol bool) (
 		}
 	}
 	return t, nil
+}
+
+func removeArrayWildcard(apiAddr swagger.PropertyAddr) swagger.PropertyAddr {
+	newApiAddr := make(swagger.PropertyAddr, 0)
+	for _, step := range apiAddr {
+		if step.Type != swagger.PropertyAddrStepTypeIndex {
+			newApiAddr = append(newApiAddr, step)
+		}
+	}
+
+	return newApiAddr
 }
 
 func azureResourceTypeFromPath(path string) (string, bool) {

--- a/aztfq/aztfq.go
+++ b/aztfq/aztfq.go
@@ -61,7 +61,7 @@ func buildLookupTable(output map[string]ctrl.ModelMap, opt Option) (LookupTable,
 
 				apiAddr := apiPos.Addr
 				if opt.ImplicitArrayIndex {
-					apiAddr = removeArrayWildcard(apiAddr)
+					apiAddr = removeArrayIndex(apiAddr)
 				}
 				apiPropAddr := apiAddr.String()
 
@@ -102,7 +102,7 @@ func buildLookupTable(output map[string]ctrl.ModelMap, opt Option) (LookupTable,
 	return t, nil
 }
 
-func removeArrayWildcard(apiAddr swagger.PropertyAddr) swagger.PropertyAddr {
+func removeArrayIndex(apiAddr swagger.PropertyAddr) swagger.PropertyAddr {
 	newApiAddr := make(swagger.PropertyAddr, 0)
 	for _, step := range apiAddr {
 		if step.Type != swagger.PropertyAddrStepTypeIndex {

--- a/aztfq/aztfq_test.go
+++ b/aztfq/aztfq_test.go
@@ -197,7 +197,7 @@ func TestBuildLookupTable(t *testing.T) {
 	}, table)
 }
 
-func TestBuildLookupTable_removeArraySymbol(t *testing.T) {
+func TestBuildLookupTable_removeArrayIndex(t *testing.T) {
 	input := `{
 	"azurerm_bar": {
 	  "/array": [{

--- a/aztfq/aztfq_test.go
+++ b/aztfq/aztfq_test.go
@@ -92,12 +92,19 @@ func TestBuildLookupTable(t *testing.T) {
 		  "path_ref": "bar.json#/paths/~1%7BresourceId%7D~1providers~1Microsoft.Bar~1bars~1%7BbarName%7D~1settings~1%7BsettingName%7D",
 		  "version": "2020-02-02"
 		}
+	  }],
+	  "/array": [{
+	   	"addr": "properties.array.*.test",
+		"root_model": {
+		  "path_ref": "bar.json#/paths/~1%7BresourceId%7D~1providers~1Microsoft.Bar~1bars~1%7BbarName%7D~1settings~1%7BsettingName%7Darray",
+		  "version": "2020-02-02"
+		}
 	  }]
 	}
 }`
 	var output map[string]ctrl.ModelMap
 	require.NoError(t, json.Unmarshal([]byte(input), &output))
-	table, err := buildLookupTable(output)
+	table, err := buildLookupTable(output, false)
 	require.NoError(t, err)
 	require.Equal(t, LookupTable{
 		"MICROSOFT.FOO/FOOS": map[string]map[string][]TFResult{
@@ -162,12 +169,158 @@ func TestBuildLookupTable(t *testing.T) {
 						PropertyAddr: "/p2",
 					},
 				},
+				"properties.array.*.test": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/array",
+					},
+				},
 			},
 			"2020-02-02": {
 				"properties.p2": {
 					{
 						ResourceType: "azurerm_bar",
 						PropertyAddr: "/p2",
+					},
+				},
+				"properties.array.*.test": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/array",
+					},
+				},
+			},
+		},
+	}, table)
+}
+
+func TestBuildLookupTable_removeArraySymbol(t *testing.T) {
+	input := `{
+	"azurerm_foo": {
+	  "/p1": [{
+	   	"addr": "properties.p1",
+		"root_model": {
+		  "path_ref": "foo.json#/paths/~1%7BresourceId%7D~1providers~1Microsoft.Foo~1foos~1%7BfooName%7D",
+		  "version": "2020-01-01"
+		}
+	  }],
+	  "/p2": [{
+	   	"addr": "properties.p2",
+		"root_model": {
+		  "path_ref": "foo.json#/paths/~1%7BresourceId%7D~1providers~1Microsoft.Foo~1foos~1%7BfooName%7D~1settings~1%7BsettingName%7D",
+		  "version": "2020-01-02"
+		}
+	  }]
+	},
+	"azurerm_bar": {
+	  "/p1": [{
+	   	"addr": "properties.p1",
+		"root_model": {
+		  "path_ref": "bar.json#/paths/~1%7BresourceId%7D~1providers~1Microsoft.Bar~1bars~1%7BbarName%7D",
+		  "version": "2020-02-01"
+		}
+	  }],
+	  "/p2": [{
+	   	"addr": "properties.p2",
+		"root_model": {
+		  "path_ref": "bar.json#/paths/~1%7BresourceId%7D~1providers~1Microsoft.Bar~1bars~1%7BbarName%7D~1settings~1%7BsettingName%7D",
+		  "version": "2020-02-02"
+		}
+	  }],
+	  "/array": [{
+	   	"addr": "properties.array.*.test",
+		"root_model": {
+		  "path_ref": "bar.json#/paths/~1%7BresourceId%7D~1providers~1Microsoft.Bar~1bars~1%7BbarName%7D~1settings~1%7BsettingName%7Darray",
+		  "version": "2020-02-02"
+		}
+	  }]
+	}
+}`
+	var output map[string]ctrl.ModelMap
+	require.NoError(t, json.Unmarshal([]byte(input), &output))
+	table, err := buildLookupTable(output, true)
+	require.NoError(t, err)
+	require.Equal(t, LookupTable{
+		"MICROSOFT.FOO/FOOS": map[string]map[string][]TFResult{
+			"": {
+				"properties.p1": {
+					{
+						ResourceType: "azurerm_foo",
+						PropertyAddr: "/p1",
+					},
+				},
+			},
+			"2020-01-01": {
+				"properties.p1": {
+					{
+						ResourceType: "azurerm_foo",
+						PropertyAddr: "/p1",
+					},
+				},
+			},
+		},
+		"MICROSOFT.FOO/FOOS/SETTINGS": map[string]map[string][]TFResult{
+			"": {
+				"properties.p2": {
+					{
+						ResourceType: "azurerm_foo",
+						PropertyAddr: "/p2",
+					},
+				},
+			},
+			"2020-01-02": {
+				"properties.p2": {
+					{
+						ResourceType: "azurerm_foo",
+						PropertyAddr: "/p2",
+					},
+				},
+			},
+		},
+		"MICROSOFT.BAR/BARS": map[string]map[string][]TFResult{
+			"": {
+				"properties.p1": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/p1",
+					},
+				},
+			},
+			"2020-02-01": {
+				"properties.p1": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/p1",
+					},
+				},
+			},
+		},
+		"MICROSOFT.BAR/BARS/SETTINGS": map[string]map[string][]TFResult{
+			"": {
+				"properties.p2": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/p2",
+					},
+				},
+				"properties.array.test": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/array",
+					},
+				},
+			},
+			"2020-02-02": {
+				"properties.p2": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/p2",
+					},
+				},
+				"properties.array.test": {
+					{
+						ResourceType: "azurerm_bar",
+						PropertyAddr: "/array",
 					},
 				},
 			},


### PR DESCRIPTION
add a argument allows removing the wildcard when build a lookup table

test
---
```
❯ go test -v ./aztfq -run=TestBuildLookupTable
=== RUN   TestBuildLookupTable
--- PASS: TestBuildLookupTable (0.00s)
=== RUN   TestBuildLookupTable_removeArraySymbol
--- PASS: TestBuildLookupTable_removeArraySymbol (0.00s)
PASS
ok      github.com/magodo/aztfq/aztfq   (cached)
```